### PR TITLE
specify version for opencv-python in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpy
-opencv-python
+opencv-python==4.3.0.36
 Pillow
 PyQt5


### PR DESCRIPTION
##Changes
1. specify version for opencv-python in requirements.txt
URL: https://askubuntu.com/questions/1310286/qt-qpa-plugin-could-not-load-the-qt-platform-plugin-xcb-in-even-though-it

Signed-off-by: Ahmed Elkashef <ahmedelkashef2012@gmail.com>